### PR TITLE
Remove inoperable error suppresion

### DIFF
--- a/upload/system/library/db/pdo.php
+++ b/upload/system/library/db/pdo.php
@@ -34,7 +34,7 @@ class PDO {
 		}
 
 		try {
-			$pdo = @new \PDO('mysql:host=' . $hostname . ';port=' . $port . ';dbname=' . $database . ';charset=utf8mb4', $username, $password, [\PDO::ATTR_PERSISTENT => false, \PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8mb4 COLLATE utf8mb4_general_ci']);
+			$pdo = new \PDO('mysql:host=' . $hostname . ';port=' . $port . ';dbname=' . $database . ';charset=utf8mb4', $username, $password, [\PDO::ATTR_PERSISTENT => false, \PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8mb4 COLLATE utf8mb4_general_ci']);
 		} catch (\PDOException $e) {
 			throw new \Exception('Error: Could not make a database link using ' . $username . '@' . $hostname . '!');
 		}


### PR DESCRIPTION
It's not possible to suppress errors on construct like `new`, and there isn't really an error that it will emit either
https://www.php.net/manual/en/language.operators.errorcontrol.php
https://www.php.net/manual/en/language.oop5.basic.php#language.oop5.basic.new